### PR TITLE
Hopefully makes Django testing work nicely with a local Informix DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ target/
 
 # Sublime Text
 *sublime-*
+
+# Environment
+.envrc

--- a/django_informixdb/creation.py
+++ b/django_informixdb/creation.py
@@ -1,4 +1,5 @@
 from django.db.backends.base.creation import BaseDatabaseCreation
+from django.db.utils import Error
 
 
 class DatabaseCreation(BaseDatabaseCreation):
@@ -11,3 +12,17 @@ class DatabaseCreation(BaseDatabaseCreation):
         if test_settings['CHARSET']:
             return "WITH ENCODING '%s'" % test_settings['CHARSET']
         return 'WITH BUFFERED LOG'
+
+    def create_test_db(self, verbosity=1, autoclobber=False, serialize=True, keepdb=False):
+        """
+        Forcing autoclobber because destroying test DB doesn't work
+
+        The keepdb option still works
+        """
+        super().create_test_db(verbosity, True, serialize, keepdb)
+
+    def _destroy_test_db(self, test_database_name, verbosity):
+        try:
+            super()._destroy_test_db(test_database_name, verbosity)
+        except Error:
+            print("Unable to destroy test database")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+    db:
+        image: ibmcom/informix-developer-database
+        tty: true # Needed to ensure container doesn't self terminate
+        environment:
+            LICENSE: accept
+            DB_USER: adapter
+            DB_NAME: adapter
+            DB_PASS: adapter
+        privileged: true
+        ports:
+            - "9088:9088"
+            - "9089:9089"
+            - "27017:27017"
+            - "27018:27018"
+            - "27883:27883"

--- a/test/testproject/settings.py
+++ b/test/testproject/settings.py
@@ -79,8 +79,8 @@ DATABASES = {
         'ENGINE': 'django_informixdb',
         'NAME': 'adapter',
         'SERVER': 'dev',
-        'USER': 'informix',
-        'PASSWORD': 'in4mix',
+        'USER': 'adapter',
+        'PASSWORD': 'adapter',
         'OPTIONS': {
             'DRIVER': '/Applications/IBM/informix/lib/cli/iclit09b.dylib'
         }


### PR DESCRIPTION
There seems to be no way to get PyODBC/unixODBC/Informix to *really* close a connection completely. As such when Django testing closes the DB connection, opens an nodb_connection and issues a `DROP DATABASE` it fails as there are open connections. Even when a dirty `sleep` is issued to give Informix time to clean up.  I've tried manually disabling connection pooling at the pyODBC level, setting `CPTime` to zero, and `CONN_MAX_AGE` to zero with no success. As well as a myriad of other unpleasant approaches. Nothing worked. 

So, this PR wraps the destroy DB in a try/except and just output a simple message when dropping the DB fails. It also overrides the create test db process to automatically destroy and existing test database (if it exist) rather than prompt the user. The `keepdb` option still does the expected thing.  So from the developers point of view Django tests do exactly what they would do normally, whilst in point of fact doing pretty much the opposite.  I also updated the `DatabaseSchemaEditor.execute` function to ignore index creation errors where the index already exists. This is because Informix automatically adds indexes to foreign keys but Django is not expecting this so try to do it effectively a second time. This was leading to some unnecessary and confusing looking warning messages in the test output.

Also, it turns out that the IBM Informix dev database Docker images does the creation of a database at start up by passing in some environmental variables. It just isn't mentioned in their readme.  So I have added a docker-compose file with the relevant variables set and updated the test project settings to match



