### PR TITLE
fix lvarchar max length issue with connection maxwrite this is the ma…

### DIFF
--- a/django_informixdb/base.py
+++ b/django_informixdb/base.py
@@ -206,6 +206,14 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.connection.setdecoding(pyodbc.SQL_WMETADATA, encoding='UTF-8')
         self.connection.setencoding(encoding='UTF-8')
 
+        # This will set SQL_C_CHAR, SQL_C_WCHAR and SQL_BINARY to 32000
+        # this max length is actually just what the database internally
+        # supports. e.g. the biggest `LONGVARCHAR` field in informix is
+        # 32000, you would need to split anything bigger over multiple fields
+        # This limit will not effect schema defined lengths, which will just
+        # truncate values greater than the limit.
+        self.connection.maxwrite = 32000
+
         self.connection.add_output_converter(-101, self._handle_constraint)
 
         return self.connection


### PR DESCRIPTION
We can override the maxwrite which will always result in a max writable length in the data base of 32000. https://github.com/mkleehammer/pyodbc/blob/57288699df86c216308c88b197812a03c2f2bf42/src/connection.h#L78
