### PR TITLE
replace informix text field with a lvarchar as pyodbc does not deal w…

### DIFF
--- a/django_informixdb/base.py
+++ b/django_informixdb/base.py
@@ -63,7 +63,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'PositiveSmallIntegerField': 'smallint',
         'SlugField': 'lvarchar(%(max_length)s)',
         'SmallIntegerField': 'smallint',
-        'TextField': 'text',
+        'TextField': 'lvarchar(%(max_length)s)',
         'TimeField': 'datetime hour to second',
         'UUIDField': 'char(32)',
     }


### PR DESCRIPTION
…ith the text type correctly. The only field left that may cause an issue is the blob field