### PR TITLE
Feature/encodings

### DIFF
--- a/django_informixdb/base.py
+++ b/django_informixdb/base.py
@@ -136,19 +136,20 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def __init__(self, *args, **kwargs):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
-        options = self.settings_dict.get('OPTIONS', None)
-        if options:
-            self.encoding = options.get('encoding', 'utf-8')
-            # make lookup operators to be collation-sensitive if needed
-            self.collation = options.get('collation', None)
-            if self.collation:
-                self.operators = dict(self.__class__.operators)
-                ops = {}
-                for op in self.operators:
-                    sql = self.operators[op]
-                    if sql.startswith('LIKE '):
-                        ops[op] = '%s COLLATE %s' % (sql, self.collation)
-                self.operators.update(ops)
+
+        options = self.settings_dict.get('OPTIONS', {})
+
+        self.encodings = options.get('encodings', ('utf-8', 'cp1252', 'iso-8859-1'))
+        # make lookup operators to be collation-sensitive if needed
+        self.collation = options.get('collation', None)
+        if self.collation:
+            self.operators = dict(self.__class__.operators)
+            ops = {}
+            for op in self.operators:
+                sql = self.operators[op]
+                if sql.startswith('LIKE '):
+                    ops[op] = '%s COLLATE %s' % (sql, self.collation)
+            self.operators.update(ops)
 
         self.features = self.features_class(self)
         self.ops = self.ops_class(self)

--- a/django_informixdb/base.py
+++ b/django_informixdb/base.py
@@ -32,6 +32,21 @@ except ImportError as e:
 logger = logging.getLogger(__name__)
 
 
+def decoder(value, encodings=('utf-8',)):
+    """This decoder tries multiple encodings before giving up"""
+
+    if not isinstance(value, binary_type):
+        raise ValueError(f"Not a binary type: {value} {type(value)}")
+
+    for enc in encodings:
+        try:
+            return value.decode(enc)
+        except UnicodeDecodeError:
+            pass
+
+    raise UnicodeDecodeError("unable to decode `{value}`")
+
+
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = 'informixdb'
     Database = pyodbc

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-version = '0.1.3'
+version = '0.1.4'
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file


### PR DESCRIPTION
* Configurable encoding (and fallback) list via `OPTIONS`
* Use this method for all char/wchar types

NB: I had previously thought the issues were flowing up from `CursorWrapper` but it was actually from something within the native side of PyODBC.

Background information: On a particular production database, columns may contain ASCII, UTF-8 and other encoded data (eg: cp1251/latin-1) at the same time. We try to at least give it a shot on the decoding side.