### PR TITLE
Add DATABASES -> TEST -> CREATE_DB flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,20 @@ Django’s settings.py require the following format to connect to an Informix da
         'PASSWORD': 'passw0rd',
         'OPTIONS': {
             'DRIVER': '/path/to/iclit09b.so'. # Or iclit09b.dylib on macOS
-        }
+        },
+	'TEST': {
+	    'NAME': 'myproject',
+	    'CREATE_DB': False
+	}
     }
 
 .. note:
     The ``DRIVER`` option is optional, default locations will be used per platform if it is not provided.
+
+.. note:
+    The ``TEST`` option sets test parametes.  Use ``NAME`` to override the name of the test database
+    and set ``CREATE_DB`` to ``False`` to prevent Django from attempting to create a new test
+    database.
 
 Using with the Docker Informix Dev Database
 -------------------------------------------
@@ -162,7 +171,10 @@ Where `informix_db_1` is the name of the running container. From this shell you 
 Testing against an Informix Database
 ------------------------------------
 
-Due to a bug in the Informix ODBC driver, it is not currently possible to run Django tests normally. Specifically, it is not possible for Django to create a test database. As such, you will need to do it manually. By default Django will attempt to create a database with a name equal to the default database name with a ``test_`` prefix. e.g. if you database name is ``my_database``, the test database name would be ``test_my_database``.
+Due to a bug in the Informix ODBC driver, it is not currently possible to run Django tests normally. Specifically, it is not possible for Django to create a test database. As such, you will need to do it manually. By default Django will attempt to create a database with a name equal to the default database name with a ``test_`` prefix. e.g. if you database name is ``my_database``, the test database name would be ``test_my_database``.  This can be overridden with the ``NAME`` option under ``TEST``.
+
+To prevent Django from attempting to create a test database, set the ``CREATE_DB`` option
+under ``TEST`` to ``False``: see 'Configure settings.py' above.
 
 You can follow the steps above, in the section on using Informix locally with Docker to create a test database. Then when running the test you can tell Django to re-use an existing database, rather than trying to create a new one with the ``-k`` parameter:
 

--- a/django_informixdb/creation.py
+++ b/django_informixdb/creation.py
@@ -19,10 +19,12 @@ class DatabaseCreation(BaseDatabaseCreation):
 
         The keepdb option still works
         """
-        super().create_test_db(verbosity, True, serialize, keepdb)
+        if self.connection.settings_dict.get('TEST', {}).get('CREATE_DB', True):
+            super().create_test_db(verbosity, True, serialize, keepdb)
 
     def _destroy_test_db(self, test_database_name, verbosity):
-        try:
-            super()._destroy_test_db(test_database_name, verbosity)
-        except Error:
-            print("Unable to destroy test database")
+        if self.connection.settings_dict.get('TEST', {}).get('CREATE_DB', True):
+            try:
+                super()._destroy_test_db(test_database_name, verbosity)
+            except Error:
+                print("Unable to destroy test database")


### PR DESCRIPTION
This disables the attempt to create or destroy the Informix test database if the CREATE_DB flag is set to False.  The flag defaults to True.

This is the same interface as exposed by the Oracle driver https://docs.djangoproject.com/en/2.0/ref/settings/#create-db

In the longer run, it would make sense for this flag to be built into Django's test code rather than into each database driver, and I intend to put a PR in for that as well, but this is a workaround for now.